### PR TITLE
Added multiple parallel bread crumbs to get to a view controller

### DIFF
--- a/example/Podfile.lock
+++ b/example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CatalogByConvention (2.1.0)
+  - CatalogByConvention (2.1.1)
   - CatalogExamples (1.0.0)
   - CatalogUnitTests (1.0.0):
     - Resistor
@@ -22,11 +22,11 @@ EXTERNAL SOURCES:
     :path: components/Resistor
 
 SPEC CHECKSUMS:
-  CatalogByConvention: ef0913973b86b4234bcadf22aa84037c4a47cbbd
+  CatalogByConvention: c3a5319de04250a7cd4649127fcfca5fe3322a43
   CatalogExamples: cafe3e4eae3abc948d96beb626657455c1dfb327
   CatalogUnitTests: b7a746f12abb31a905654521ee926ea007ab7275
   Resistor: 36a9ae98666be3b4f34d8133fad442fa87fdbce2
 
 PODFILE CHECKSUM: bb59c09c71f8777bbe79af5ae920e3d58849ab41
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/example/catalog/Catalog.xcodeproj/project.pbxproj
+++ b/example/catalog/Catalog.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		526A63F3210C836C577F3F5D /* [CP] Copy Pods Resources */ = {

--- a/example/catalog/UnitTests.xcodeproj/project.pbxproj
+++ b/example/catalog/UnitTests.xcodeproj/project.pbxproj
@@ -175,7 +175,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E2A6B4BD8988E7DF3FD232F4 /* [CP] Copy Pods Resources */ = {

--- a/example/components/Resistor/examples/SeriesExample.m
+++ b/example/components/Resistor/examples/SeriesExample.m
@@ -18,15 +18,15 @@
 
 #import <UIKit/UIKit.h>
 
-@interface SeriesResistorExample : UIViewController
+@interface SeriesExample : UIViewController
 @end
 
-@implementation SeriesResistorExample
+@implementation SeriesExample
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    self.title = @"Series resistors";
+    self.title = @"Series";
   }
   return self;
 }
@@ -39,10 +39,10 @@
 
 @end
 
-@implementation SeriesResistorExample (CatalogByConvention)
+@implementation SeriesExample (CatalogByConvention)
 
 + (NSArray<NSString *> *)catalogBreadcrumbs {
-  return @[ @"Resistor", @"Series" ];
+  return @[ @[ @"Resistor", @"Series"], @[ @"Film", @"Series" ], @[@"Botany", @"Series"] ];
 }
 
 @end

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -19,6 +19,8 @@
 #import "CBCCatalogExample.h"
 #import "private/CBCRuntime.h"
 
+void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, Class aClass);
+
 @implementation CBCNode {
   NSMutableDictionary *_map;
   NSMutableArray *_children;
@@ -177,26 +179,13 @@ CBCNode *CBCCreateNavigationTree(void) {
 
     NSArray *breadCrumbs = CBCCatalogBreadcrumbsFromClass(aClass);
 
-    // Walk down the navigation tree one breadcrumb at a time, creating nodes along the way.
-
-    CBCNode *node = tree;
-    for (NSUInteger ix = 0; ix < [breadCrumbs count]; ++ix) {
-      NSString *title = breadCrumbs[ix];
-      BOOL isLastCrumb = ix == [breadCrumbs count] - 1;
-
-      // Don't walk the last crumb
-
-      if (node.map[title] && !isLastCrumb) {
-        node = node.map[title];
-        continue;
+    if ([[breadCrumbs firstObject] isKindOfClass:[NSString class]]) {
+      CBCAddNodeFromBreadCrumbs(tree, breadCrumbs, aClass);
+    } else if ([[breadCrumbs firstObject] isKindOfClass:[NSArray class]]) {
+      for (NSArray<NSString *> *parallelBreadCrumb in breadCrumbs) {
+        CBCAddNodeFromBreadCrumbs(tree, parallelBreadCrumb, aClass);
       }
-
-      CBCNode *child = [[CBCNode alloc] initWithTitle:title];
-      [node addChild:child];
-      node = child;
     }
-
-    node.exampleClass = aClass;
   }
 
   // Perform final post-processing on the nodes.
@@ -210,4 +199,27 @@ CBCNode *CBCCreateNavigationTree(void) {
   }
 
   return tree;
+}
+
+void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, Class aClass) {
+  // Walk down the navigation tree one breadcrumb at a time, creating nodes along the way.
+
+  CBCNode *node = tree;
+  for (NSUInteger ix = 0; ix < [breadCrumbs count]; ++ix) {
+    NSString *title = breadCrumbs[ix];
+    BOOL isLastCrumb = ix == [breadCrumbs count] - 1;
+
+    // Don't walk the last crumb
+
+    if (node.map[title] && !isLastCrumb) {
+      node = node.map[title];
+      continue;
+    }
+
+    CBCNode *child = [[CBCNode alloc] initWithTitle:title];
+    [node addChild:child];
+    node = child;
+  }
+
+  node.exampleClass = aClass;
 }


### PR DESCRIPTION
If you specify an array of arrays it looks at each array of strings as steps to get to the view controller.

This makes it so an example that belongs in two categories possible.

```
+ (NSArray<NSString *> *)catalogBreadcrumbs {
  return @[ @[ @"Resistor", @"Series"], @[ @"Film", @"Series" ], @[@"Botany", @"Series"] ];
}
```

The example catalog now looks like:
Resistor -> Parallel
Resistor -> Series
Film -> Series
Botany -> Series