### PR TITLE
Add kokoro continuous build script.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+# Display commands to stderr.
+set -x
+
+gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+
+sudo xcode-select --switch /Applications/Xcode_8.2.app/Contents/Developer
+xcodebuild -version
+
+cd github/repo
+xcodebuild clean build -project CatalogByConvention/CatalogByConvention.xcodeproj -sdk "iphonesimulator" | xcpretty
+
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Note that we're just building the Carthage target and using the default build settings. Ideally this script would run through a matrix of platforms and SDKs, maybe even Xcode versions, but I'll pursue that functionality in a follow-up change.

Additional info:
We can set up different scripts for continuous integration vs pull request presubmits. Right now everything runs through the same script. I'll probably explore making presubmits be the fastest-possible "smoke" build, with the continuous integrations being a full matrix of SDKs and Xcode versions.