### PR TITLE
Additional functionality to CbC to support Dragons

### DIFF
--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -28,12 +28,14 @@
 /** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
 + (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
 
-+ (nonnull NSArray<NSString *> *)dragonBreadcrumbs;
 /**
  Return a BOOL stating whether this example should be treated as the primary demo of the component.
  */
 + (BOOL)catalogIsPrimaryDemo;
 
+/**
+ Return a BOOL stating whether this example is presentable and should be part of the catalog app.
+ */
 + (BOOL)catalogIsPresentable;
 
 @optional

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -28,10 +28,13 @@
 /** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
 + (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
 
++ (nonnull NSArray<NSString *> *)dragonBreadcrumbs;
 /**
  Return a BOOL stating whether this example should be treated as the primary demo of the component.
  */
 + (BOOL)catalogIsPrimaryDemo;
+
++ (BOOL)catalogIsPresentable;
 
 @optional
 

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -38,6 +38,11 @@
  */
 + (BOOL)catalogIsPresentable;
 
+/**
+ Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
+ */
++ (BOOL)catalogIsDebug;
+
 @optional
 
 /**

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -43,6 +43,7 @@
  the tree.
  */
 FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreateNavigationTree(void);
+FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
 /**
  A node describes a single navigable page in the Catalog by Convention.
@@ -76,6 +77,8 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreateNavigationTree(void);
  Can only return YES if isExample also returns YES.
  */
 - (BOOL)isPrimaryDemo;
+
+- (BOOL)isPresentable;
 
 /** Returns String representation of exampleViewController class name if it exists */
 - (nullable NSString *)exampleViewControllerName;

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -43,6 +43,13 @@
  the tree.
  */
 FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreateNavigationTree(void);
+
+/**
+ Returns the root of a CBCNode tree representing only the presentable catalog navigation hierarchy.
+
+ Only classes that implement +catalogIsPresentable and +catalogBreadcrumbs and return at least one breadcrumb will be part of
+ the tree.
+ */
 FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
 /**
@@ -78,6 +85,7 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
  */
 - (BOOL)isPrimaryDemo;
 
+/** Returns YES if this is a presentable example.  */
 - (BOOL)isPresentable;
 
 /** Returns String representation of exampleViewController class name if it exists */

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -47,8 +47,8 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreateNavigationTree(void);
 /**
  Returns the root of a CBCNode tree representing only the presentable catalog navigation hierarchy.
 
- Only classes that implement +catalogIsPresentable and +catalogBreadcrumbs and return at least one breadcrumb will be part of
- the tree.
+ Only classes that implement +catalogIsPresentable with a return value of YES,
+ and +catalogBreadcrumbs and return at least one breadcrumb will be part of the tree.
  */
 FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
@@ -75,7 +75,12 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 /** The children of this node. */
 @property(nonatomic, strong, nonnull) NSArray<CBCNode *> *children;
 
-/** The example you wish to debug as the initial view controller. */
+/**
+ The example you wish to debug as the initial view controller.
+ If there are multiple examples with catalogIsDebug returning YES
+ the debugLeaf will hold the example that has been iterated on last
+ in the hierarchy tree.
+ */
 @property(nonatomic, strong, nullable) CBCNode *debugLeaf;
 
 /** Returns YES if this is an example node. */

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -75,6 +75,9 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 /** The children of this node. */
 @property(nonatomic, strong, nonnull) NSArray<CBCNode *> *children;
 
+/** The example you wish to debug as the initial view controller. */
+@property(nonatomic, strong, nullable) CBCNode *debugLeaf;
+
 /** Returns YES if this is an example node. */
 - (BOOL)isExample;
 

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -179,7 +179,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 
 @end
 
-CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
+static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   NSArray *allClasses = CBCGetAllClasses();
   NSArray *breadcrumbClasses = CBCClassesRespondingToSelector(allClasses,
                                                               @selector(catalogBreadcrumbs));

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -90,7 +90,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 }
 
 - (BOOL)isPresentable {
-  return CBCCatalogIsPresentableFromClass(_exampleClass) || _isPresentable;
+  return _isPresentable;
 }
 
 @end

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -246,6 +246,9 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
     [node setIsPresentable:aClass];
+    if (CBCCatalogIsDebugLeaf(aClass)) {
+      tree.debugLeaf = child;
+    }
     node = child;
   }
 

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -28,6 +28,9 @@ FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
 /** Invokes +catalogIsPresentable on the class and returns the BOOL value. */
 FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
 
+/** Invokes +catalogIsDebug on the class and returns the BOOL value. */
+FOUNDATION_EXTERN BOOL CBCCatalogIsDebugLeaf(Class aClass);
+
 #pragma mark Runtime enumeration
 
 /** Returns all Objective-C and Swift classes available to the runtime. */

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -25,6 +25,7 @@ FOUNDATION_EXTERN NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aCla
 /** Invokes +catalogIsPrimaryDemo on the class and returns the BOOL value. */
 FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
 
+/** Invokes +catalogIsPresentable on the class and returns the BOOL value. */
 FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
 
 #pragma mark Runtime enumeration

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -40,6 +40,12 @@ FOUNDATION_EXTERN NSArray<Class> *CBCGetAllClasses(void);
 FOUNDATION_EXTERN NSArray<Class> *CBCClassesRespondingToSelector(NSArray<Class> *classes,
                                                                  SEL selector);
 
+/**
+ Internal helper method that allows invoking aClass with selector and puts
+ the return value in retValue.
+ */
+void CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector, void *retValue);
+
 #pragma mark UIViewController instantiation
 
 /**

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -25,6 +25,8 @@ FOUNDATION_EXTERN NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aCla
 /** Invokes +catalogIsPrimaryDemo on the class and returns the BOOL value. */
 FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
 
+FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
+
 #pragma mark Runtime enumeration
 
 /** Returns all Objective-C and Swift classes available to the runtime. */

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -44,6 +44,22 @@ BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   return isPrimaryDemo;
 }
 
+BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
+  BOOL isPresentable = NO;
+
+  if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
+    NSMethodSignature *signature =
+    [aClass methodSignatureForSelector:@selector(catalogIsPresentable)];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.selector = @selector(catalogIsPresentable);
+    invocation.target = aClass;
+    [invocation invoke];
+    [invocation getReturnValue:&isPresentable];
+  }
+
+  return isPresentable;
+}
+
 #pragma mark Runtime enumeration
 
 NSArray<Class> *CBCGetAllClasses(void) {

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -28,35 +28,33 @@ NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
 
 #pragma mark Primary demo check
 
-BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
-  BOOL isPrimaryDemo = NO;
-
-  if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
+void *CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector) {
+  void *retValue = nil;
+  if ([aClass respondsToSelector:@selector(selector)]) {
     NSMethodSignature *signature =
-        [aClass methodSignatureForSelector:@selector(catalogIsPrimaryDemo)];
+    [aClass methodSignatureForSelector:@selector(selector)];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    invocation.selector = @selector(catalogIsPrimaryDemo);
+    NSUInteger length = [signature methodReturnLength];
+    void *retValue = (void *)malloc(length);
+    invocation.selector = @selector(selector);
     invocation.target = aClass;
     [invocation invoke];
-    [invocation getReturnValue:&isPrimaryDemo];
+    [invocation getReturnValue:&retValue];
   }
+  return retValue;
+}
 
+BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
+  BOOL isPrimaryDemo = NO;
+  isPrimaryDemo = (BOOL)CBCCatalogInvokeFromClassAndSelector(aClass,
+                                                             @selector(catalogIsPrimaryDemo));
   return isPrimaryDemo;
 }
 
 BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   BOOL isPresentable = NO;
-
-  if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
-    NSMethodSignature *signature =
-    [aClass methodSignatureForSelector:@selector(catalogIsPresentable)];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    invocation.selector = @selector(catalogIsPresentable);
-    invocation.target = aClass;
-    [invocation invoke];
-    [invocation getReturnValue:&isPresentable];
-  }
-
+  isPresentable = (BOOL)CBCCatalogInvokeFromClassAndSelector(aClass,
+                                                             @selector(catalogIsPresentable));
   return isPresentable;
 }
 

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -30,13 +30,13 @@ NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
 
 void *CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector) {
   void *retValue = nil;
-  if ([aClass respondsToSelector:@selector(selector)]) {
+  if ([aClass respondsToSelector:selector]) {
     NSMethodSignature *signature =
-    [aClass methodSignatureForSelector:@selector(selector)];
+    [aClass methodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     NSUInteger length = [signature methodReturnLength];
     void *retValue = (void *)malloc(length);
-    invocation.selector = @selector(selector);
+    invocation.selector = selector;
     invocation.target = aClass;
     [invocation invoke];
     [invocation getReturnValue:&retValue];

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -35,27 +35,25 @@ void *CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector) {
     [aClass methodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     NSUInteger length = [signature methodReturnLength];
-    void *retValue = (void *)malloc(length);
+    retValue = (void *)malloc(length);
     invocation.selector = selector;
     invocation.target = aClass;
     [invocation invoke];
-    [invocation getReturnValue:&retValue];
+    [invocation getReturnValue:retValue];
   }
   return retValue;
 }
 
 BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
-  BOOL isPrimaryDemo = NO;
-  isPrimaryDemo = (BOOL)CBCCatalogInvokeFromClassAndSelector(aClass,
-                                                             @selector(catalogIsPrimaryDemo));
-  return isPrimaryDemo;
+  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
+                                                                @selector(catalogIsPrimaryDemo));
+  return retValue != nil ? *retValue : NO;
 }
 
 BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
-  BOOL isPresentable = NO;
-  isPresentable = (BOOL)CBCCatalogInvokeFromClassAndSelector(aClass,
-                                                             @selector(catalogIsPresentable));
-  return isPresentable;
+  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
+                                                                @selector(catalogIsPresentable));
+  return retValue != nil ? *retValue : NO;
 }
 
 #pragma mark Runtime enumeration

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -56,6 +56,12 @@ BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   return retValue != nil ? *retValue : NO;
 }
 
+BOOL CBCCatalogIsDebugLeaf(Class aClass) {
+  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
+                                                                @selector(catalogIsDebug));
+  return retValue != nil ? *retValue : NO;
+}
+
 #pragma mark Runtime enumeration
 
 NSArray<Class> *CBCGetAllClasses(void) {

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -28,38 +28,40 @@ NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
 
 #pragma mark Primary demo check
 
-void *CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector) {
-  void *retValue = nil;
+void CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector, void *retValue) {
   if ([aClass respondsToSelector:selector]) {
     NSMethodSignature *signature =
     [aClass methodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    NSUInteger length = [signature methodReturnLength];
-    retValue = (void *)malloc(length);
     invocation.selector = selector;
     invocation.target = aClass;
     [invocation invoke];
-    [invocation getReturnValue:retValue];
+    [invocation getReturnValue:&retValue];
   }
-  return retValue;
 }
 
 BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
-  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
-                                                                @selector(catalogIsPrimaryDemo));
-  return retValue != nil ? *retValue : NO;
+  BOOL isPrimary = NO;
+  CBCCatalogInvokeFromClassAndSelector(aClass,
+                                       @selector(catalogIsPrimaryDemo),
+                                       &isPrimary);
+  return isPrimary;
 }
 
 BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
-  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
-                                                                @selector(catalogIsPresentable));
-  return retValue != nil ? *retValue : NO;
+  BOOL isPresentable = NO;
+  CBCCatalogInvokeFromClassAndSelector(aClass,
+                                       @selector(catalogIsPresentable),
+                                       &isPresentable);
+  return isPresentable;
 }
 
 BOOL CBCCatalogIsDebugLeaf(Class aClass) {
-  BOOL *retValue = (BOOL *)CBCCatalogInvokeFromClassAndSelector(aClass,
-                                                                @selector(catalogIsDebug));
-  return retValue != nil ? *retValue : NO;
+  BOOL isDebugLeaf = NO;
+  CBCCatalogInvokeFromClassAndSelector(aClass,
+                                       @selector(catalogIsDebug),
+                                       &isDebugLeaf);
+  return isDebugLeaf;
 }
 
 #pragma mark Runtime enumeration


### PR DESCRIPTION
1. There are now 2 navigation tree creation methods; the existing one `CBCCreateNavigationTree`, which is still backwards compatible with the existing behavior, and a new one called `CBCCreateTreeWithOnlyPresentable` which will only create a navigation tree with the presentable examples (ones we want to show in the catalog app).
2. There is an added method called `catalogIsPresentable`. If an example is worthy of being presented in the catalog app, it needs to implement that method and return `YES`, and it will magically appear in the catalog app. Examples who don't implement that method or have it set to return `NO` will only appear in the Dragons app.
3. There is an added method called `catalogIsDebug`. If an example implements this method and sets it to return `YES`, this example will appear as the initial view controller in the Dragons app.
4. Minor improvements to the invoke selector code block to allow multiple usages in different cases.

Main Catalog PR soon to follow.