### PR TITLE
minor bug causing the release not to return correct booleans for isPresentable.

### DIFF
--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -36,7 +36,7 @@ void CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector, void *retV
     invocation.selector = selector;
     invocation.target = aClass;
     [invocation invoke];
-    [invocation getReturnValue:&retValue];
+    [invocation getReturnValue:retValue];
   }
 }
 


### PR DESCRIPTION
bug introduced with the PR fixes, whilst moving the returnvalue to be part of the signature, the & for the return value wasn't dereferenced.