### PR TITLE
[Runtime] Only select UIViewController subclasses

### DIFF
--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -94,6 +94,9 @@ NSArray<Class> *CBCGetAllClasses(void) {
     if (hasIgnoredPrefix) {
       continue;
     }
+    if (![aClass isSubclassOfClass:[UIViewController class]]) {
+      continue;
+    }
     [classes addObject:aClass];
   }
 


### PR DESCRIPTION
Any example being shown by the Catalog By Convention is a UIViewController (or
subclass). Execution of Catalog By Convention code can be reduced by up to 15%
(672 ms to 570 ms in one test) by performing this filter before checking
response to the selector `catalogBreadcrumbs`.

Closes #21