### PR TITLE
added a new metadata property that will hold all the key/values for that node. Also code refactoring

### DIFF
--- a/example/Podfile.lock
+++ b/example/Podfile.lock
@@ -22,11 +22,11 @@ EXTERNAL SOURCES:
     :path: components/Resistor
 
 SPEC CHECKSUMS:
-  CatalogByConvention: 1df2d770271921f668a99245c7c4c129e78941ee
-  CatalogExamples: cafe3e4eae3abc948d96beb626657455c1dfb327
-  CatalogUnitTests: b7a746f12abb31a905654521ee926ea007ab7275
-  Resistor: 36a9ae98666be3b4f34d8133fad442fa87fdbce2
+  CatalogByConvention: f4b95f8905470807a5022eabd1d3d9ce07f6a66f
+  CatalogExamples: 7a95e6ea7befbd43c5ceb1427a9b161f6d8fc34e
+  CatalogUnitTests: 2fbf7f2e894dd3777f11573a7a5314adb1e4fad7
+  Resistor: a17e39cab5f42993c2b3ede22ce3829b707a9ac8
 
 PODFILE CHECKSUM: bb59c09c71f8777bbe79af5ae920e3d58849ab41
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -16,6 +16,21 @@
 
 #import <Foundation/Foundation.h>
 
+/** This key represents a boolean value if to present the example in the Catalog app or not */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPresentable;
+/** This key represents a strings array of the breadcrumbs showing the hierarchy of the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCBreadcrumbs;
+/** This key represents a string for the description for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCDescription;
+/** This key represents a boolean value if the example is for debugging */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsDebug;
+/** This key represents a boolean value if the example is the primary demo */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPrimaryDemo;
+/** This key represents an NSURL value providing related info for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCRelatedInfo;
+/** This key represents a string value of the storyboard name for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCStoryboardName;
+
 /**
  The CBCCatalogExample protocol defines methods that examples are expected to implement in order to
  customize their location and behavior in the Catalog by Convention.
@@ -34,38 +49,38 @@
 
 /** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
 + (nonnull NSArray<NSString *> *)catalogBreadcrumbs
-  __attribute__((deprecated("use catalogMetadata[\"breadcrumbs\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCBreadcrumbs] instead.")));
 
 /**
  Return a BOOL stating whether this example should be treated as the primary demo of the component.
  */
 + (BOOL)catalogIsPrimaryDemo
-  __attribute__((deprecated("use catalogMetadata[\"primaryDemo\"] instead.")));;
+  __attribute__((deprecated("use catalogMetadata[CBCIsPrimaryDemo] instead.")));;
 
 /**
  Return a BOOL stating whether this example is presentable and should be part of the catalog app.
  */
 + (BOOL)catalogIsPresentable
-  __attribute__((deprecated("use catalogMetadata[\"presentable\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCIsPresentable] instead.")));
 
 /**
  Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
  */
 + (BOOL)catalogIsDebug
-  __attribute__((deprecated("use catalogMetadata[\"debug\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCIsDebug] instead.")));
 
 /**
  Return the name of a UIStoryboard from which the example's view controller should be instantiated.
  */
 - (nonnull NSString *)catalogStoryboardName
-  __attribute__((deprecated("use catalogMetadata[\"storyboardName\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCStoryboardName] instead.")));
 
 /** Return a description of the example. */
 - (nonnull NSString *)catalogDescription
-  __attribute__((deprecated("use catalogMetadata[\"description\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCDescription] instead.")));
 
 /** Return a link to related information or resources. */
 - (nonnull NSURL *)catalogRelatedInfo
-  __attribute__((deprecated("use catalogMetadata[\"relatedInfo\"] instead.")));
+  __attribute__((deprecated("use catalogMetadata[CBCRelatedInfo] instead.")));
 
 @end

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -16,21 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-/** This key represents a boolean value if to present the example in the Catalog app or not */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPresentable;
-/** This key represents a strings array of the breadcrumbs showing the hierarchy of the example */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCBreadcrumbs;
-/** This key represents a string for the description for the example */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCDescription;
-/** This key represents a boolean value if the example is for debugging */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCIsDebug;
-/** This key represents a boolean value if the example is the primary demo */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPrimaryDemo;
-/** This key represents an NSURL value providing related info for the example */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCRelatedInfo;
-/** This key represents a string value of the storyboard name for the example */
-FOUNDATION_EXTERN NSString *_Nonnull const CBCStoryboardName;
-
 /**
  The CBCCatalogExample protocol defines methods that examples are expected to implement in order to
  customize their location and behavior in the Catalog by Convention.

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -25,37 +25,47 @@
  */
 @protocol CBCCatalogExample <NSObject>
 
-/** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
-+ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
-
 /**
- Return a BOOL stating whether this example should be treated as the primary demo of the component.
+ Returns a dictionary with metaata information for the example.
  */
-+ (BOOL)catalogIsPrimaryDemo;
-
-/**
- Return a BOOL stating whether this example is presentable and should be part of the catalog app.
- */
-+ (BOOL)catalogIsPresentable;
-
-/**
- Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
- */
-+ (BOOL)catalogIsDebug;
-
 + (nonnull NSDictionary<NSString *, NSObject *> *)catalogMetadata;
 
 @optional
 
+/** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
++ (nonnull NSArray<NSString *> *)catalogBreadcrumbs
+  __attribute__((deprecated("use catalogMetadata[\"breadcrumbs\"] instead.")));
+
+/**
+ Return a BOOL stating whether this example should be treated as the primary demo of the component.
+ */
++ (BOOL)catalogIsPrimaryDemo
+  __attribute__((deprecated("use catalogMetadata[\"primaryDemo\"] instead.")));;
+
+/**
+ Return a BOOL stating whether this example is presentable and should be part of the catalog app.
+ */
++ (BOOL)catalogIsPresentable
+  __attribute__((deprecated("use catalogMetadata[\"presentable\"] instead.")));
+
+/**
+ Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
+ */
++ (BOOL)catalogIsDebug
+  __attribute__((deprecated("use catalogMetadata[\"debug\"] instead.")));
+
 /**
  Return the name of a UIStoryboard from which the example's view controller should be instantiated.
  */
-- (nonnull NSString *)catalogStoryboardName;
+- (nonnull NSString *)catalogStoryboardName
+  __attribute__((deprecated("use catalogMetadata[\"storyboardName\"] instead.")));
 
 /** Return a description of the example. */
-- (nonnull NSString *)catalogDescription;
+- (nonnull NSString *)catalogDescription
+  __attribute__((deprecated("use catalogMetadata[\"description\"] instead.")));
 
 /** Return a link to related information or resources. */
-- (nonnull NSURL *)catalogRelatedInfo;
+- (nonnull NSURL *)catalogRelatedInfo
+  __attribute__((deprecated("use catalogMetadata[\"relatedInfo\"] instead.")));
 
 @end

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -26,17 +26,17 @@
 @protocol CBCCatalogExample <NSObject>
 
 /** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
-//+ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
++ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
 
 /**
  Return a BOOL stating whether this example should be treated as the primary demo of the component.
  */
-//+ (BOOL)catalogIsPrimaryDemo;
++ (BOOL)catalogIsPrimaryDemo;
 
 /**
  Return a BOOL stating whether this example is presentable and should be part of the catalog app.
  */
-//+ (BOOL)catalogIsPresentable;
++ (BOOL)catalogIsPresentable;
 
 /**
  Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
@@ -50,12 +50,12 @@
 /**
  Return the name of a UIStoryboard from which the example's view controller should be instantiated.
  */
-//- (nonnull NSString *)catalogStoryboardName;
+- (nonnull NSString *)catalogStoryboardName;
 
 /** Return a description of the example. */
-//- (nonnull NSString *)catalogDescription;
+- (nonnull NSString *)catalogDescription;
 
 /** Return a link to related information or resources. */
-//- (nonnull NSURL *)catalogRelatedInfo;
+- (nonnull NSURL *)catalogRelatedInfo;
 
 @end

--- a/src/CBCCatalogExample.h
+++ b/src/CBCCatalogExample.h
@@ -26,34 +26,36 @@
 @protocol CBCCatalogExample <NSObject>
 
 /** Return a list of breadcrumbs defining the navigation path taken to reach this example. */
-+ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
+//+ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
 
 /**
  Return a BOOL stating whether this example should be treated as the primary demo of the component.
  */
-+ (BOOL)catalogIsPrimaryDemo;
+//+ (BOOL)catalogIsPrimaryDemo;
 
 /**
  Return a BOOL stating whether this example is presentable and should be part of the catalog app.
  */
-+ (BOOL)catalogIsPresentable;
+//+ (BOOL)catalogIsPresentable;
 
 /**
  Return a BOOL stating whether this example is in debug mode and should appear as the initial view controller.
  */
 + (BOOL)catalogIsDebug;
 
++ (nonnull NSDictionary<NSString *, NSObject *> *)catalogMetadata;
+
 @optional
 
 /**
  Return the name of a UIStoryboard from which the example's view controller should be instantiated.
  */
-- (nonnull NSString *)catalogStoryboardName;
+//- (nonnull NSString *)catalogStoryboardName;
 
 /** Return a description of the example. */
-- (nonnull NSString *)catalogDescription;
+//- (nonnull NSString *)catalogDescription;
 
 /** Return a link to related information or resources. */
-- (nonnull NSURL *)catalogRelatedInfo;
+//- (nonnull NSURL *)catalogRelatedInfo;
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -69,9 +69,6 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 /** The title for this node. */
 @property(nonatomic, copy, nonnull, readonly) NSString *title;
 
-/** The description for this node. */
-@property(nonatomic, copy, nonnull, readonly) NSString *nodeDescription;
-
 /** The children of this node. */
 @property(nonatomic, strong, nonnull) NSArray<CBCNode *> *children;
 

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -113,6 +113,9 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
  Check that isExample returns YES before invoking.
  */
-- (nonnull NSString *)exampleDescription;
+- (nullable NSString *)exampleDescription;
+
+/** Returns a link to related information for the example. */
+- (nullable NSURL *)exampleRelatedInfo;
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -83,6 +83,11 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
  */
 @property(nonatomic, strong, nullable) CBCNode *debugLeaf;
 
+/**
+ This NSDictionary holds all the metadata related to this CBCNode.
+ If it is an example noe, a primary demo, related info,
+ if presentable in Catalog, etc.
+ */
 @property(nonatomic, strong, nonnull) NSDictionary *metadata;
 
 /** Returns YES if this is an example node. */
@@ -93,10 +98,10 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
  Can only return YES if isExample also returns YES.
  */
-- (BOOL)isPrimaryDemo;
+- (BOOL)isPrimaryDemo __attribute__((deprecated("use metadata[\"primaryDemo\"] instead.")));
 
 /** Returns YES if this is a presentable example.  */
-- (BOOL)isPresentable;
+- (BOOL)isPresentable __attribute__((deprecated("use metadata[\"presentable\"] instead.")));
 
 /** Returns String representation of exampleViewController class name if it exists */
 - (nullable NSString *)exampleViewControllerName;
@@ -113,9 +118,9 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
  Check that isExample returns YES before invoking.
  */
-- (nullable NSString *)exampleDescription;
+- (nullable NSString *)exampleDescription __attribute__((deprecated("use metadata[\"description\"] instead.")));
 
 /** Returns a link to related information for the example. */
-- (nullable NSURL *)exampleRelatedInfo;
+- (nullable NSURL *)exampleRelatedInfo __attribute__((deprecated("use metadata[\"relatedInfo\"] instead.")));
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -16,6 +16,21 @@
 
 #import <UIKit/UIKit.h>
 
+/** This key represents a strings array of the breadcrumbs showing the hierarchy of the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCBreadcrumbs;
+/** This key represents a boolean value if the example is for debugging */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsDebug;
+/** This key represents a string for the description for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCDescription;
+/** This key represents a boolean value if to present the example in the Catalog app or not */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPresentable;
+/** This key represents a boolean value if the example is the primary demo */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCIsPrimaryDemo;
+/** This key represents an NSURL value providing related info for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCRelatedInfo;
+/** This key represents a string value of the storyboard name for the example */
+FOUNDATION_EXTERN NSString *_Nonnull const CBCStoryboardName;
+
 @class CBCNode;
 
 /**

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -95,10 +95,10 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
  Can only return YES if isExample also returns YES.
  */
-- (BOOL)isPrimaryDemo __attribute__((deprecated("use metadata[\"primaryDemo\"] instead.")));
+- (BOOL)isPrimaryDemo;
 
 /** Returns YES if this is a presentable example.  */
-- (BOOL)isPresentable __attribute__((deprecated("use metadata[\"presentable\"] instead.")));
+- (BOOL)isPresentable;
 
 /** Returns String representation of exampleViewController class name if it exists */
 - (nullable NSString *)exampleViewControllerName;
@@ -115,9 +115,9 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 
  Check that isExample returns YES before invoking.
  */
-- (nullable NSString *)exampleDescription __attribute__((deprecated("use metadata[\"description\"] instead.")));
+- (nullable NSString *)exampleDescription;
 
 /** Returns a link to related information for the example. */
-- (nullable NSURL *)exampleRelatedInfo __attribute__((deprecated("use metadata[\"relatedInfo\"] instead.")));
+- (nullable NSURL *)exampleRelatedInfo;
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -83,34 +83,36 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
  */
 @property(nonatomic, strong, nullable) CBCNode *debugLeaf;
 
+@property(nonatomic, strong, nonnull) NSDictionary *metadata;
+
 /** Returns YES if this is an example node. */
-- (BOOL)isExample;
+//- (BOOL)isExample;
 
 /**
  Returns YES if this the primary demo for this component.
 
  Can only return YES if isExample also returns YES.
  */
-- (BOOL)isPrimaryDemo;
+//- (BOOL)isPrimaryDemo;
 
 /** Returns YES if this is a presentable example.  */
-- (BOOL)isPresentable;
+//- (BOOL)isPresentable;
 
 /** Returns String representation of exampleViewController class name if it exists */
-- (nullable NSString *)exampleViewControllerName;
+//- (nullable NSString *)exampleViewControllerName;
 
 /**
  Returns an instance of a UIViewController for presentation purposes.
 
  Check that isExample returns YES before invoking.
  */
-- (nonnull UIViewController *)createExampleViewController;
+//- (nonnull UIViewController *)createExampleViewController;
 
 /**
  Returns a description of the example.
 
  Check that isExample returns YES before invoking.
  */
-- (nonnull NSString *)exampleDescription;
+//- (nonnull NSString *)exampleDescription;
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -86,33 +86,33 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 @property(nonatomic, strong, nonnull) NSDictionary *metadata;
 
 /** Returns YES if this is an example node. */
-//- (BOOL)isExample;
+- (BOOL)isExample;
 
 /**
  Returns YES if this the primary demo for this component.
 
  Can only return YES if isExample also returns YES.
  */
-//- (BOOL)isPrimaryDemo;
+- (BOOL)isPrimaryDemo;
 
 /** Returns YES if this is a presentable example.  */
-//- (BOOL)isPresentable;
+- (BOOL)isPresentable;
 
 /** Returns String representation of exampleViewController class name if it exists */
-//- (nullable NSString *)exampleViewControllerName;
+- (nullable NSString *)exampleViewControllerName;
 
 /**
  Returns an instance of a UIViewController for presentation purposes.
 
  Check that isExample returns YES before invoking.
  */
-//- (nonnull UIViewController *)createExampleViewController;
+- (nonnull UIViewController *)createExampleViewController;
 
 /**
  Returns a description of the example.
 
  Check that isExample returns YES before invoking.
  */
-//- (nonnull NSString *)exampleDescription;
+- (nonnull NSString *)exampleDescription;
 
 @end

--- a/src/CBCNodeListViewController.h
+++ b/src/CBCNodeListViewController.h
@@ -135,7 +135,4 @@ FOUNDATION_EXTERN CBCNode *_Nonnull CBCCreatePresentableNavigationTree(void);
 /** Returns a link to related information for the example. */
 - (nullable NSURL *)exampleRelatedInfo;
 
-/** Returns a link to related information for the example. */
-- (nullable NSURL *)exampleRelatedInfo;
-
 @end

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -206,6 +206,9 @@ static void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
     child.metadata = metadata;
+    if ([[child.metadata objectForKey:CBCIsPrimaryDemo] boolValue]) {
+      node.metadata = child.metadata;
+    }
     if ([[child.metadata objectForKey:CBCIsDebug] boolValue] == YES) {
       tree.debugLeaf = child;
     }

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -74,16 +74,16 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
 }
 
 - (NSString *)exampleDescription {
-  NSString *description;
-  if ((description = [self.metadata objectForKey:@"description"]) != nil) {
+  NSString *description = [self.metadata objectForKey:@"description"];
+  if (description != nil && [description isKindOfClass:[NSString class]]) {
     return description;
   }
   return nil;
 }
 
 - (NSURL *)exampleRelatedInfo {
-  NSURL *relatedInfo;
-  if ((relatedInfo = [self.metadata objectForKey:@"relatedInfo"]) != nil) {
+  NSURL *relatedInfo = [self.metadata objectForKey:@"relatedInfo"];
+  if (relatedInfo != nil && [relatedInfo isKindOfClass:[NSURL class]]) {
     return relatedInfo;
   }
   return nil;
@@ -196,7 +196,8 @@ static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   NSArray *filteredClasses = [allClasses filteredArrayUsingPredicate:
                     [NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *bindings) {
     NSDictionary *metadata = CBCCatalogMetadataFromClass(object);
-    BOOL validObject = [metadata objectForKey:@"breadcrumbs"] != nil;
+    id breadcrumbs = [metadata objectForKey:@"breadcrumbs"];
+    BOOL validObject =  breadcrumbs != nil && [breadcrumbs isKindOfClass:[NSArray class]];
     if (onlyPresentable) {
       validObject &= ([[metadata objectForKey:@"presentable"] boolValue] == YES);
     }

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -230,7 +230,7 @@ static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
 
   CBCNode *tree = [[CBCNode alloc] initWithTitle:@"Root"];
   for (Class aClass in filteredClasses) {
-    // Each example view controller defines its own "breadcrumbs".
+    // Each example view controller defines its own breadcrumbs (metadata[CBCBreadcrumbs]).
     NSDictionary *metadata = CBCCatalogMetadataFromClass(aClass);
     NSArray *breadCrumbs = [metadata objectForKey:CBCBreadcrumbs];
     if ([[breadCrumbs firstObject] isKindOfClass:[NSString class]]) {

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -54,7 +54,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
 }
 
 - (void)finalizeNode {
-  _children = [[_children sortedArrayUsingSelector:@selector(compare:)] copy];
+  _children = [[_children sortedArrayUsingSelector:@selector(compare:)] mutableCopy];
 }
 
 #pragma mark Public

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -193,7 +193,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 @end
 
 static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
-  NSArray *allClasses = CBCGetAllClasses();
+  NSArray *allClasses = CBCGetAllCompatibleClasses();
   NSArray *filteredClasses = [allClasses filteredArrayUsingPredicate:
                     [NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *bindings) {
     NSDictionary *metadata = CBCCatalogMetadataFromClass(object);
@@ -207,8 +207,8 @@ static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   CBCNode *tree = [[CBCNode alloc] initWithTitle:@"Root"];
   for (Class aClass in filteredClasses) {
     // Each example view controller defines its own "breadcrumbs".
-
-    NSArray *breadCrumbs = [CBCCatalogMetadataFromClass(aClass) objectForKey:@"breadcrumbs"];
+    NSDictionary *metadata = CBCCatalogMetadataFromClass(aClass);
+    NSArray *breadCrumbs = [metadata objectForKey:@"breadcrumbs"];
     if ([[breadCrumbs firstObject] isKindOfClass:[NSString class]]) {
       CBCAddNodeFromBreadCrumbs(tree, breadCrumbs, aClass);
     } else if ([[breadCrumbs firstObject] isKindOfClass:[NSArray class]]) {
@@ -248,7 +248,6 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
     BOOL isLastCrumb = ix == [breadCrumbs count] - 1;
 
     // Don't walk the last crumb
-
     if (node.map[title] && !isLastCrumb) {
       node = node.map[title];
       continue;

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -69,7 +69,7 @@
 }
 
 - (NSString *)exampleDescription {
-  NSString *description = [self.metadata objectForKey:@"description"];
+  NSString *description = [self.metadata objectForKey:CBCDescription];
   if (description != nil && [description isKindOfClass:[NSString class]]) {
     return description;
   }
@@ -77,7 +77,7 @@
 }
 
 - (NSURL *)exampleRelatedInfo {
-  NSURL *relatedInfo = [self.metadata objectForKey:@"relatedInfo"];
+  NSURL *relatedInfo = [self.metadata objectForKey:CBCRelatedInfo];
   if (relatedInfo != nil && [relatedInfo isKindOfClass:[NSURL class]]) {
     return relatedInfo;
   }
@@ -86,7 +86,7 @@
 
 - (BOOL)isPrimaryDemo {
   id isPrimaryDemo;
-  if ((isPrimaryDemo = [self.metadata objectForKey:@"primaryDemo"]) != nil) {
+  if ((isPrimaryDemo = [self.metadata objectForKey:CBCIsPrimaryDemo]) != nil) {
     return [isPrimaryDemo boolValue];
   }
   return NO;
@@ -94,7 +94,7 @@
 
 - (BOOL)isPresentable {
   id isPresentable;
-  if ((isPresentable = [self.metadata objectForKey:@"presentable"]) != nil) {
+  if ((isPresentable = [self.metadata objectForKey:CBCIsPresentable]) != nil) {
     return [isPresentable boolValue];
   }
   return NO;
@@ -206,7 +206,7 @@ static void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
     child.metadata = metadata;
-    if ([[node.metadata objectForKey:@"debug"] boolValue] == YES) {
+    if ([[node.metadata objectForKey:CBCIsDebug] boolValue] == YES) {
       tree.debugLeaf = child;
     }
     node = child;
@@ -220,10 +220,10 @@ static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   NSArray *filteredClasses = [allClasses filteredArrayUsingPredicate:
                     [NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *bindings) {
     NSDictionary *metadata = CBCCatalogMetadataFromClass(object);
-    id breadcrumbs = [metadata objectForKey:@"breadcrumbs"];
+    id breadcrumbs = [metadata objectForKey:CBCBreadcrumbs];
     BOOL validObject =  breadcrumbs != nil && [breadcrumbs isKindOfClass:[NSArray class]];
     if (onlyPresentable) {
-      validObject &= ([[metadata objectForKey:@"presentable"] boolValue] == YES);
+      validObject &= ([[metadata objectForKey:CBCIsPresentable] boolValue] == YES);
     }
     return validObject;
   }]];
@@ -232,7 +232,7 @@ static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   for (Class aClass in filteredClasses) {
     // Each example view controller defines its own "breadcrumbs".
     NSDictionary *metadata = CBCCatalogMetadataFromClass(aClass);
-    NSArray *breadCrumbs = [metadata objectForKey:@"breadcrumbs"];
+    NSArray *breadCrumbs = [metadata objectForKey:CBCBreadcrumbs];
     if ([[breadCrumbs firstObject] isKindOfClass:[NSString class]]) {
       CBCAddNodeFromBreadCrumbs(tree, breadCrumbs, aClass, metadata);
     } else if ([[breadCrumbs firstObject] isKindOfClass:[NSArray class]]) {

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -206,7 +206,7 @@ static void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
     child.metadata = metadata;
-    if ([[node.metadata objectForKey:CBCIsDebug] boolValue] == YES) {
+    if ([[child.metadata objectForKey:CBCIsDebug] boolValue] == YES) {
       tree.debugLeaf = child;
     }
     node = child;

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -25,18 +25,12 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
                                NSDictionary *metadata);
 
 @interface CBCNode()
-
 @property(nonatomic, strong, nullable) NSMutableDictionary *map;
 @property(nonatomic, strong, nullable) Class exampleClass;
-//@property(nonatomic, strong, nullable) NSMutableArray *mutableChildren;
-
 @end
 
 @implementation CBCNode {
-//  NSMutableDictionary *_map;
   NSMutableArray *_children;
-//  Class _exampleClass;
-//  BOOL _isPresentable;
 }
 
 - (instancetype)initWithTitle:(NSString *)title {
@@ -45,7 +39,6 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
     _title = [title copy];
     self.map = [NSMutableDictionary dictionary];
     _children = [NSMutableArray array];
-//    _isPresentable = NO;
     CBCFixViewDebuggingIfNeeded();
   }
   return self;
@@ -59,18 +52,6 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
   self.map[child.title] = child;
   [_children addObject:child];
 }
-
-//- (NSDictionary *)map {
-//  return _map;
-//}
-
-//- (void)setExampleClass:(Class)exampleClass {
-//  self.exampleClass = exampleClass;
-//}
-//
-//- (void)setIsPresentable:(Class)exampleClass {
-//  _isPresentable = CBCCatalogIsPresentableFromClass(exampleClass);
-//}
 
 - (void)finalizeNode {
   _children = [[_children sortedArrayUsingSelector:@selector(compare:)] copy];

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -206,7 +206,7 @@ static void CBCAddNodeFromBreadCrumbs(CBCNode *tree,
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
     child.metadata = metadata;
-    if ([[child.metadata objectForKey:CBCIsPrimaryDemo] boolValue]) {
+    if ([[child.metadata objectForKey:CBCIsPrimaryDemo] boolValue] == YES) {
       node.metadata = child.metadata;
     }
     if ([[child.metadata objectForKey:CBCIsDebug] boolValue] == YES) {

--- a/src/CBCNodeListViewController.m
+++ b/src/CBCNodeListViewController.m
@@ -21,20 +21,28 @@
 
 void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, Class aClass);
 
+@interface CBCNode()
+
+@property(nonatomic, strong, nullable) NSMutableDictionary *map;
+@property(nonatomic, strong, nullable) Class exampleClass;
+@property(nonatomic, strong, nullable) NSMutableArray *mutableChildren;
+
+@end
+
 @implementation CBCNode {
-  NSMutableDictionary *_map;
-  NSMutableArray *_children;
-  Class _exampleClass;
-  BOOL _isPresentable;
+//  NSMutableDictionary *_map;
+//  NSMutableArray *_children;
+//  Class _exampleClass;
+//  BOOL _isPresentable;
 }
 
 - (instancetype)initWithTitle:(NSString *)title {
   self = [super init];
   if (self) {
     _title = [title copy];
-    _map = [NSMutableDictionary dictionary];
-    _children = [NSMutableArray array];
-    _isPresentable = NO;
+    self.map = [NSMutableDictionary dictionary];
+    self.mutableChildren = [NSMutableArray array];
+//    _isPresentable = NO;
     CBCFixViewDebuggingIfNeeded();
   }
   return self;
@@ -45,72 +53,72 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 }
 
 - (void)addChild:(CBCNode *)child {
-  _map[child.title] = child;
-  [_children addObject:child];
+  self.map[child.title] = child;
+  [self.mutableChildren addObject:child];
 }
 
-- (NSDictionary *)map {
-  return _map;
-}
+//- (NSDictionary *)map {
+//  return _map;
+//}
 
-- (void)setExampleClass:(Class)exampleClass {
-  _exampleClass = exampleClass;
-}
-
-- (void)setIsPresentable:(Class)exampleClass {
-  _isPresentable = CBCCatalogIsPresentableFromClass(exampleClass);
-}
+//- (void)setExampleClass:(Class)exampleClass {
+//  self.exampleClass = exampleClass;
+//}
+//
+//- (void)setIsPresentable:(Class)exampleClass {
+//  _isPresentable = CBCCatalogIsPresentableFromClass(exampleClass);
+//}
 
 - (void)finalizeNode {
-  _children = [[_children sortedArrayUsingSelector:@selector(compare:)] mutableCopy];
+  self.children = [[self.mutableChildren sortedArrayUsingSelector:@selector(compare:)] copy];
 }
 
 #pragma mark Public
 
 - (BOOL)isExample {
-  return _exampleClass != nil;
+  return self.exampleClass != nil;
 }
-
-- (NSString *)exampleViewControllerName {
-  return NSStringFromClass(_exampleClass);
-}
-
+//
+//- (NSString *)exampleViewControllerName {
+//  return NSStringFromClass(_exampleClass);
+//}
+//
 - (UIViewController *)createExampleViewController {
-  NSAssert(_exampleClass != nil, @"This node has no associated example.");
-  return CBCViewControllerFromClass(_exampleClass);
+  NSAssert(self.exampleClass != nil, @"This node has no associated example.");
+  return CBCViewControllerFromClass(self.exampleClass, self.metadata);
 }
-
-- (NSString *)exampleDescription {
-  NSAssert(_exampleClass != nil, @"This node has no associated example.");
-  return CBCDescriptionFromClass(_exampleClass);
-}
-
-- (NSURL *)exampleRelatedInfo {
-  NSAssert(_exampleClass != nil, @"This node has no associated example.");
-  return CBCRelatedInfoFromClass(_exampleClass);
-}
-
-- (BOOL)isPrimaryDemo {
-  return CBCCatalogIsPrimaryDemoFromClass(_exampleClass);
-}
-
-- (BOOL)isPresentable {
-  return _isPresentable;
-}
+//
+//- (NSString *)exampleDescription {
+//  NSAssert(_exampleClass != nil, @"This node has no associated example.");
+//  return CBCDescriptionFromClass(_exampleClass);
+//}
+//
+//- (NSURL *)exampleRelatedInfo {
+//  NSAssert(_exampleClass != nil, @"This node has no associated example.");
+//  return CBCRelatedInfoFromClass(_exampleClass);
+//}
+//
+//- (BOOL)isPrimaryDemo {
+//  return CBCCatalogIsPrimaryDemoFromClass(_exampleClass);
+//}
+//
+//- (BOOL)isPresentable {
+//  return _isPresentable;
+//}
 
 @end
 
 @implementation CBCNodeListViewController
 
 - (instancetype)initWithNode:(CBCNode *)node {
-  NSAssert(!_node.isExample, @"%@ cannot represent example nodes.",
+  NSAssert(!self.node.isExample, @"%@ cannot represent example nodes.",
            NSStringFromClass([self class]));
 
   self = [super initWithNibName:nil bundle:nil];
   if (self) {
     _node = node;
 
-    self.title = _node.title;
+    self.title = self.node.title;
   }
   return self;
 }
@@ -154,7 +162,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-  return (NSInteger)[_node.children count];
+  return (NSInteger)[self.node.children count];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView
@@ -164,7 +172,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
     cell =
         [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
-  cell.textLabel.text = [_node.children[(NSUInteger)indexPath.row] title];
+  cell.textLabel.text = [self.node.children[(NSUInteger)indexPath.row] title];
   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
   return cell;
 }
@@ -172,7 +180,7 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 #pragma mark - UITableViewDelegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-  CBCNode *node = _node.children[(NSUInteger)indexPath.row];
+  CBCNode *node = self.node.children[(NSUInteger)indexPath.row];
   UIViewController *viewController = nil;
   if ([node isExample]) {
     viewController = [node createExampleViewController];
@@ -186,23 +194,21 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 
 static CBCNode *CBCCreateTreeWithOnlyPresentable(BOOL onlyPresentable) {
   NSArray *allClasses = CBCGetAllClasses();
-  NSArray *breadcrumbClasses = CBCClassesRespondingToSelector(allClasses,
-                                                              @selector(catalogBreadcrumbs));
-  NSArray *classes;
-  if (onlyPresentable) {
-    classes = [breadcrumbClasses filteredArrayUsingPredicate:
-               [NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *bindings) {
-      return CBCCatalogIsPresentableFromClass(object);
-    }]];
-  } else {
-    classes = breadcrumbClasses;
-  }
+  NSArray *filteredClasses = [allClasses filteredArrayUsingPredicate:
+                    [NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *bindings) {
+    NSDictionary *metadata = CBCCatalogMetadataFromClass(object);
+    BOOL validObject = [metadata objectForKey:@"breadcrumbs"] != nil;
+    if (onlyPresentable) {
+      validObject &= ([[metadata objectForKey:@"presentable"] boolValue] == YES);
+    }
+    return validObject;
+  }]];
+
   CBCNode *tree = [[CBCNode alloc] initWithTitle:@"Root"];
-  for (Class aClass in classes) {
+  for (Class aClass in filteredClasses) {
     // Each example view controller defines its own "breadcrumbs".
 
-    NSArray *breadCrumbs = CBCCatalogBreadcrumbsFromClass(aClass);
-
+    NSArray *breadCrumbs = [CBCCatalogMetadataFromClass(aClass) objectForKey:@"breadcrumbs"];
     if ([[breadCrumbs firstObject] isKindOfClass:[NSString class]]) {
       CBCAddNodeFromBreadCrumbs(tree, breadCrumbs, aClass);
     } else if ([[breadCrumbs firstObject] isKindOfClass:[NSArray class]]) {
@@ -250,8 +256,8 @@ void CBCAddNodeFromBreadCrumbs(CBCNode *tree, NSArray<NSString *> *breadCrumbs, 
 
     CBCNode *child = [[CBCNode alloc] initWithTitle:title];
     [node addChild:child];
-    [node setIsPresentable:aClass];
-    if (CBCCatalogIsDebugLeaf(aClass)) {
+    node.metadata = CBCCatalogMetadataFromClass(aClass);
+    if ([[node.metadata objectForKey:@"debug"] boolValue] == YES) {
       tree.debugLeaf = child;
     }
     node = child;

--- a/src/CatalogByConvention.h
+++ b/src/CatalogByConvention.h
@@ -15,4 +15,3 @@
  */
 
 #import "CBCNodeListViewController.h"
-#import "CBCCatalogExample.h"

--- a/src/CatalogByConvention.h
+++ b/src/CatalogByConvention.h
@@ -15,3 +15,4 @@
  */
 
 #import "CBCNodeListViewController.h"
+#import "CBCCatalogExample.h"

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -17,7 +17,24 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#pragma mark Class Invocations
+#pragma mark Metadata keys
+
+/** This key represents a boolean value if to present the example in the Catalog app or not */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCIsPresentable;
+/** This key represents a strings array of the breadcrumbs showing the hierarchy of the example */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCBreadcrumbs;
+/** This key represents a string for the description for the example */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCDescription;
+/** This key represents a boolean value if the example is for debugging */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCIsDebug;
+/** This key represents a boolean value if the example is the primary demo */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCIsPrimaryDemo;
+/** This key represents an NSURL value providing related info for the example */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCRelatedInfo;
+/** This key represents a string value of the storyboard name for the example */
+FOUNDATION_EXTERN NSAttributedStringKey const CBCStoryboardName;
+
+#pragma mark Class invocations
 
 /** Invokes +catalogMetadata on the class and returns the NSDictionary value */
 FOUNDATION_EXTERN NSDictionary *CBCCatalogMetadataFromClass(Class aClass);

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -17,23 +17,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#pragma mark Metadata keys
-
-/** This key represents a boolean value if to present the example in the Catalog app or not */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCIsPresentable;
-/** This key represents a strings array of the breadcrumbs showing the hierarchy of the example */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCBreadcrumbs;
-/** This key represents a string for the description for the example */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCDescription;
-/** This key represents a boolean value if the example is for debugging */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCIsDebug;
-/** This key represents a boolean value if the example is the primary demo */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCIsPrimaryDemo;
-/** This key represents an NSURL value providing related info for the example */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCRelatedInfo;
-/** This key represents a string value of the storyboard name for the example */
-FOUNDATION_EXTERN NSAttributedStringKey const CBCStoryboardName;
-
 #pragma mark Class invocations
 
 /** Invokes +catalogMetadata on the class and returns the NSDictionary value */

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -17,19 +17,27 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#pragma mark Breadcrumb retrieval
+#pragma mark Class Invocations
 
 /** Invokes +catalogBreadcrumbs on the class and returns the corresponding array of strings. */
-FOUNDATION_EXTERN NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass);
+//FOUNDATION_EXTERN NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass);
 
 /** Invokes +catalogIsPrimaryDemo on the class and returns the BOOL value. */
-FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
+//FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
 
 /** Invokes +catalogIsPresentable on the class and returns the BOOL value. */
-FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
+//FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
 
 /** Invokes +catalogIsDebug on the class and returns the BOOL value. */
-FOUNDATION_EXTERN BOOL CBCCatalogIsDebugLeaf(Class aClass);
+//FOUNDATION_EXTERN BOOL CBCCatalogIsDebugLeaf(Class aClass);
+
+/** Create a description from the provided class. **/
+//FOUNDATION_EXTERN NSString *CBCDescriptionFromClass(Class aClass);
+
+/** Create a link to related information from the provided class. **/
+//FOUNDATION_EXTERN NSURL *CBCRelatedInfoFromClass(Class aClass);
+
+FOUNDATION_EXTERN NSDictionary *CBCCatalogMetadataFromClass(Class aClass);
 
 #pragma mark Runtime enumeration
 
@@ -55,13 +63,7 @@ void CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector, void *retV
  be created with the returned name. The returned view controller will be instantiated by invoking
  -instantiateInitialViewController on the UIStoryboard instance.
  */
-FOUNDATION_EXTERN UIViewController *CBCViewControllerFromClass(Class aClass);
-
-/** Create a description from the provided class. **/
-FOUNDATION_EXTERN NSString *CBCDescriptionFromClass(Class aClass);
-
-/** Create a link to related information from the provided class. **/
-FOUNDATION_EXTERN NSURL *CBCRelatedInfoFromClass(Class aClass);
+FOUNDATION_EXTERN UIViewController *CBCViewControllerFromClass(Class aClass, NSDictionary *metadata);
 
 #pragma mark Fix View Debugging
 

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -42,7 +42,7 @@ FOUNDATION_EXTERN NSDictionary *CBCCatalogMetadataFromClass(Class aClass);
 #pragma mark Runtime enumeration
 
 /** Returns all Objective-C and Swift classes available to the runtime. */
-FOUNDATION_EXTERN NSArray<Class> *CBCGetAllClasses(void);
+FOUNDATION_EXTERN NSArray<Class> *CBCGetAllCompatibleClasses(void);
 
 /** Returns an array of classes that respond to a given static method selector. */
 FOUNDATION_EXTERN NSArray<Class> *CBCClassesRespondingToSelector(NSArray<Class> *classes,

--- a/src/private/CBCRuntime.h
+++ b/src/private/CBCRuntime.h
@@ -19,24 +19,7 @@
 
 #pragma mark Class Invocations
 
-/** Invokes +catalogBreadcrumbs on the class and returns the corresponding array of strings. */
-//FOUNDATION_EXTERN NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass);
-
-/** Invokes +catalogIsPrimaryDemo on the class and returns the BOOL value. */
-//FOUNDATION_EXTERN BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
-
-/** Invokes +catalogIsPresentable on the class and returns the BOOL value. */
-//FOUNDATION_EXTERN BOOL CBCCatalogIsPresentableFromClass(Class aClass);
-
-/** Invokes +catalogIsDebug on the class and returns the BOOL value. */
-//FOUNDATION_EXTERN BOOL CBCCatalogIsDebugLeaf(Class aClass);
-
-/** Create a description from the provided class. **/
-//FOUNDATION_EXTERN NSString *CBCDescriptionFromClass(Class aClass);
-
-/** Create a link to related information from the provided class. **/
-//FOUNDATION_EXTERN NSURL *CBCRelatedInfoFromClass(Class aClass);
-
+/** Invokes +catalogMetadata on the class and returns the NSDictionary value */
 FOUNDATION_EXTERN NSDictionary *CBCCatalogMetadataFromClass(Class aClass);
 
 #pragma mark Runtime enumeration

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -18,7 +18,17 @@
 #import "CBCCatalogExample.h"
 #import <objc/runtime.h>
 
-#pragma mark Class Invocations
+#pragma mark Metadata keys
+
+NSAttributedStringKey const CBCIsPresentable  = @"presentable";
+NSAttributedStringKey const CBCBreadcrumbs    = @"breadcrumbs";
+NSAttributedStringKey const CBCDescription    = @"description";
+NSAttributedStringKey const CBCIsDebug        = @"debug";
+NSAttributedStringKey const CBCIsPrimaryDemo  = @"primaryDemo";
+NSAttributedStringKey const CBCRelatedInfo    = @"relatedInfo";
+NSAttributedStringKey const CBCStoryboardName = @"storyboardName";
+
+#pragma mark Class invocations
 
 static NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
   return [aClass performSelector:@selector(catalogBreadcrumbs)];
@@ -75,24 +85,24 @@ static NSString *CBCStoryboardNameFromClass(Class aClass) {
 static NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
   NSMutableDictionary *catalogMetadata = [NSMutableDictionary new];
   if ([aClass respondsToSelector:@selector(catalogBreadcrumbs)]) {
-    [catalogMetadata setObject:CBCCatalogBreadcrumbsFromClass(aClass) forKey:@"breadcrumbs"];
+    [catalogMetadata setObject:CBCCatalogBreadcrumbsFromClass(aClass) forKey:CBCBreadcrumbs];
     [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsPrimaryDemoFromClass(aClass)]
-                        forKey:@"primaryDemo"];
+                        forKey:CBCIsPrimaryDemo];
     [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsPresentableFromClass(aClass)]
-                        forKey:@"presentable"];
+                        forKey:CBCIsPresentable];
     [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsDebugLeaf(aClass)]
-                        forKey:@"debug"];
+                        forKey:CBCIsDebug];
     NSURL *relatedInfo;
     if ((relatedInfo = CBCRelatedInfoFromClass(aClass)) != nil) {
-      [catalogMetadata setObject:CBCRelatedInfoFromClass(aClass) forKey:@"relatedInfo"];
+      [catalogMetadata setObject:CBCRelatedInfoFromClass(aClass) forKey:CBCRelatedInfo];
     }
     NSString *description;
     if ((description = CBCDescriptionFromClass(aClass)) != nil) {
-      [catalogMetadata setObject:CBCDescriptionFromClass(aClass) forKey:@"description"];
+      [catalogMetadata setObject:CBCDescriptionFromClass(aClass) forKey:CBCDescription];
     }
     NSString *storyboardName;
     if ((storyboardName = CBCStoryboardNameFromClass(aClass)) != nil) {
-      [catalogMetadata setObject:CBCStoryboardNameFromClass(aClass) forKey:@"storyboardName"];
+      [catalogMetadata setObject:CBCStoryboardNameFromClass(aClass) forKey:CBCStoryboardName];
     }
   }
   return catalogMetadata;
@@ -162,8 +172,8 @@ NSArray<Class> *CBCClassesRespondingToSelector(NSArray<Class> *classes, SEL sele
 #pragma mark UIViewController instantiation
 
 UIViewController *CBCViewControllerFromClass(Class aClass, NSDictionary *metadata) {
-  if ([metadata objectForKey:@"storyboardName"]) {
-    NSString *storyboardName = [metadata objectForKey:@"storyboardName"];
+  if ([metadata objectForKey:CBCStoryboardName]) {
+    NSString *storyboardName = [metadata objectForKey:CBCStoryboardName];
     NSBundle *bundle = [NSBundle bundleForClass:aClass];
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
     NSCAssert(storyboard, @"expecting a storyboard to exist at %@", storyboardName);

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -22,46 +22,58 @@
 
 #pragma mark Breadcrumb retrieval
 
-NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
-  return [aClass performSelector:@selector(catalogBreadcrumbs)];
-}
+//NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
+//  return [aClass performSelector:@selector(catalogBreadcrumbs)];
+//}
 
-#pragma mark Primary demo check
+#pragma mark Class Invocations
 
-void CBCCatalogInvokeFromClassAndSelector(Class aClass, SEL selector, void *retValue) {
-  if ([aClass respondsToSelector:selector]) {
-    NSMethodSignature *signature =
-    [aClass methodSignatureForSelector:selector];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    invocation.selector = selector;
-    invocation.target = aClass;
-    [invocation invoke];
-    [invocation getReturnValue:retValue];
+//BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
+//  BOOL isPrimary = NO;
+//  if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
+//    isPrimary = [aClass catalogIsPrimaryDemo];
+//  }
+//  return isPrimary;
+//}
+
+//BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
+//  BOOL isPresentable = NO;
+//  if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
+//    isPresentable = [aClass catalogIsPresentable];
+//  }
+//  return isPresentable;
+//}
+
+//BOOL CBCCatalogIsDebugLeaf(Class aClass) {
+//  BOOL isDebugLeaf = NO;
+//  if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
+//    isDebugLeaf = [aClass catalogIsDebug];
+//  }
+//  return isDebugLeaf;
+//}
+
+//NSURL *CBCRelatedInfoFromClass(Class aClass) {
+//  NSURL *catalogRelatedInfo = nil;
+//  if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
+//    catalogRelatedInfo = [aClass catalogRelatedInfo];
+//  }
+//  return catalogRelatedInfo;
+//}
+
+//NSString *CBCDescriptionFromClass(Class aClass) {
+//  NSString *catalogDescription = nil;
+//  if ([aClass respondsToSelector:@selector(catalogDescription)]) {
+//    catalogDescription = [aClass catalogDescription];
+//  }
+//  return catalogDescription;
+//}
+
+NSDictionary *CBCCatalogMetadataFromClass(Class aClass) {
+  NSDictionary *catalogMetadata = [NSDictionary new];
+  if ([aClass respondsToSelector:@selector(catalogMetadata)]) {
+    catalogMetadata = [aClass catalogMetadata];
   }
-}
-
-BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
-  BOOL isPrimary = NO;
-  CBCCatalogInvokeFromClassAndSelector(aClass,
-                                       @selector(catalogIsPrimaryDemo),
-                                       &isPrimary);
-  return isPrimary;
-}
-
-BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
-  BOOL isPresentable = NO;
-  CBCCatalogInvokeFromClassAndSelector(aClass,
-                                       @selector(catalogIsPresentable),
-                                       &isPresentable);
-  return isPresentable;
-}
-
-BOOL CBCCatalogIsDebugLeaf(Class aClass) {
-  BOOL isDebugLeaf = NO;
-  CBCCatalogInvokeFromClassAndSelector(aClass,
-                                       @selector(catalogIsDebug),
-                                       &isDebugLeaf);
-  return isDebugLeaf;
+  return catalogMetadata;
 }
 
 #pragma mark Runtime enumeration
@@ -117,9 +129,9 @@ NSArray<Class> *CBCClassesRespondingToSelector(NSArray<Class> *classes, SEL sele
 
 #pragma mark UIViewController instantiation
 
-UIViewController *CBCViewControllerFromClass(Class aClass) {
-  if ([aClass respondsToSelector:@selector(catalogStoryboardName)]) {
-    NSString *storyboardName = [aClass catalogStoryboardName];
+UIViewController *CBCViewControllerFromClass(Class aClass, NSDictionary *metadata) {
+  if ([metadata objectForKey:@"storyboardName"]) {
+    NSString *storyboardName = [metadata objectForKey:@"storyboardName"];
     NSBundle *bundle = [NSBundle bundleForClass:aClass];
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
     NSCAssert(storyboard, @"expecting a storyboard to exist at %@", storyboardName);
@@ -128,22 +140,6 @@ UIViewController *CBCViewControllerFromClass(Class aClass) {
     return vc;
   }
   return [[aClass alloc] init];
-}
-
-NSString *CBCDescriptionFromClass(Class aClass) {
-  if ([aClass respondsToSelector:@selector(catalogDescription)]) {
-    NSString *catalogDescription = [aClass catalogDescription];
-    return catalogDescription;
-  }
-  return nil;
-}
-
-NSURL *CBCRelatedInfoFromClass(Class aClass) {
-  if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
-    NSURL *catalogRelatedInfo = [aClass catalogRelatedInfo];
-    return catalogRelatedInfo;
-  }
-  return nil;
 }
 
 #pragma mark Fix View Debugging

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -20,13 +20,13 @@
 
 #pragma mark Metadata keys
 
-NSAttributedStringKey const CBCIsPresentable  = @"presentable";
-NSAttributedStringKey const CBCBreadcrumbs    = @"breadcrumbs";
-NSAttributedStringKey const CBCDescription    = @"description";
-NSAttributedStringKey const CBCIsDebug        = @"debug";
-NSAttributedStringKey const CBCIsPrimaryDemo  = @"primaryDemo";
-NSAttributedStringKey const CBCRelatedInfo    = @"relatedInfo";
-NSAttributedStringKey const CBCStoryboardName = @"storyboardName";
+NSString *const CBCIsPresentable  = @"presentable";
+NSString *const CBCBreadcrumbs    = @"breadcrumbs";
+NSString *const CBCDescription    = @"description";
+NSString *const CBCIsDebug        = @"debug";
+NSString *const CBCIsPrimaryDemo  = @"primaryDemo";
+NSString *const CBCRelatedInfo    = @"relatedInfo";
+NSString *const CBCStoryboardName = @"storyboardName";
 
 #pragma mark Class invocations
 

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -78,7 +78,7 @@ NSDictionary *CBCCatalogMetadataFromClass(Class aClass) {
 
 #pragma mark Runtime enumeration
 
-NSArray<Class> *CBCGetAllClasses(void) {
+NSArray<Class> *CBCGetAllCompatibleClasses(void) {
   int numberOfClasses = objc_getClassList(NULL, 0);
   Class *classList = (Class *)malloc((size_t)numberOfClasses * sizeof(Class));
   objc_getClassList(classList, numberOfClasses);

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -28,6 +28,7 @@ NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
 
 #pragma mark Class Invocations
 
+__attribute__((deprecated))
 BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   BOOL isPrimary = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
@@ -36,6 +37,7 @@ BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   return isPrimary;
 }
 
+__attribute__((deprecated))
 BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   BOOL isPresentable = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
@@ -44,6 +46,7 @@ BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   return isPresentable;
 }
 
+__attribute__((deprecated))
 BOOL CBCCatalogIsDebugLeaf(Class aClass) {
   BOOL isDebugLeaf = NO;
   if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
@@ -52,6 +55,7 @@ BOOL CBCCatalogIsDebugLeaf(Class aClass) {
   return isDebugLeaf;
 }
 
+__attribute__((deprecated))
 NSURL *CBCRelatedInfoFromClass(Class aClass) {
   NSURL *catalogRelatedInfo = nil;
   if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
@@ -60,6 +64,7 @@ NSURL *CBCRelatedInfoFromClass(Class aClass) {
   return catalogRelatedInfo;
 }
 
+__attribute__((deprecated))
 NSString *CBCDescriptionFromClass(Class aClass) {
   NSString *catalogDescription = nil;
   if ([aClass respondsToSelector:@selector(catalogDescription)]) {
@@ -68,6 +73,7 @@ NSString *CBCDescriptionFromClass(Class aClass) {
   return catalogDescription;
 }
 
+__attribute__((deprecated))
 NSString *CBCStoryboardNameFromClass(Class aClass) {
   NSString *catalogStoryboardName = nil;
   if ([aClass respondsToSelector:@selector(catalogStoryboardName)]) {
@@ -76,6 +82,7 @@ NSString *CBCStoryboardNameFromClass(Class aClass) {
   return catalogStoryboardName;
 }
 
+__attribute__((deprecated))
 NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
   NSMutableDictionary *catalogMetadata = [NSMutableDictionary new];
   if ([aClass respondsToSelector:@selector(catalogBreadcrumbs)]) {

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -22,56 +22,92 @@
 
 #pragma mark Breadcrumb retrieval
 
-//NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
-//  return [aClass performSelector:@selector(catalogBreadcrumbs)];
-//}
+NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
+  return [aClass performSelector:@selector(catalogBreadcrumbs)];
+}
 
 #pragma mark Class Invocations
 
-//BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
-//  BOOL isPrimary = NO;
-//  if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
-//    isPrimary = [aClass catalogIsPrimaryDemo];
-//  }
-//  return isPrimary;
-//}
+BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
+  BOOL isPrimary = NO;
+  if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
+    isPrimary = [aClass catalogIsPrimaryDemo];
+  }
+  return isPrimary;
+}
 
-//BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
-//  BOOL isPresentable = NO;
-//  if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
-//    isPresentable = [aClass catalogIsPresentable];
-//  }
-//  return isPresentable;
-//}
+BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
+  BOOL isPresentable = NO;
+  if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
+    isPresentable = [aClass catalogIsPresentable];
+  }
+  return isPresentable;
+}
 
-//BOOL CBCCatalogIsDebugLeaf(Class aClass) {
-//  BOOL isDebugLeaf = NO;
-//  if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
-//    isDebugLeaf = [aClass catalogIsDebug];
-//  }
-//  return isDebugLeaf;
-//}
+BOOL CBCCatalogIsDebugLeaf(Class aClass) {
+  BOOL isDebugLeaf = NO;
+  if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
+    isDebugLeaf = [aClass catalogIsDebug];
+  }
+  return isDebugLeaf;
+}
 
-//NSURL *CBCRelatedInfoFromClass(Class aClass) {
-//  NSURL *catalogRelatedInfo = nil;
-//  if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
-//    catalogRelatedInfo = [aClass catalogRelatedInfo];
-//  }
-//  return catalogRelatedInfo;
-//}
+NSURL *CBCRelatedInfoFromClass(Class aClass) {
+  NSURL *catalogRelatedInfo = nil;
+  if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
+    catalogRelatedInfo = [aClass catalogRelatedInfo];
+  }
+  return catalogRelatedInfo;
+}
 
-//NSString *CBCDescriptionFromClass(Class aClass) {
-//  NSString *catalogDescription = nil;
-//  if ([aClass respondsToSelector:@selector(catalogDescription)]) {
-//    catalogDescription = [aClass catalogDescription];
-//  }
-//  return catalogDescription;
-//}
+NSString *CBCDescriptionFromClass(Class aClass) {
+  NSString *catalogDescription = nil;
+  if ([aClass respondsToSelector:@selector(catalogDescription)]) {
+    catalogDescription = [aClass catalogDescription];
+  }
+  return catalogDescription;
+}
+
+NSString *CBCStoryboardNameFromClass(Class aClass) {
+  NSString *catalogStoryboardName = nil;
+  if ([aClass respondsToSelector:@selector(catalogStoryboardName)]) {
+    catalogStoryboardName = [aClass catalogStoryboardName];
+  }
+  return catalogStoryboardName;
+}
+
+NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
+  NSMutableDictionary *catalogMetadata = [NSMutableDictionary new];
+  if ([aClass respondsToSelector:@selector(catalogBreadcrumbs)]) {
+    [catalogMetadata setObject:CBCCatalogBreadcrumbsFromClass(aClass) forKey:@"breadcrumbs"];
+    [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsPrimaryDemoFromClass(aClass)]
+                        forKey:@"primaryDemo"];
+    [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsPresentableFromClass(aClass)]
+                        forKey:@"presentable"];
+    [catalogMetadata setObject:[NSNumber numberWithBool:CBCCatalogIsDebugLeaf(aClass)]
+                        forKey:@"debug"];
+    NSURL *relatedInfo;
+    if ((relatedInfo = CBCRelatedInfoFromClass(aClass)) != nil) {
+      [catalogMetadata setObject:CBCRelatedInfoFromClass(aClass) forKey:@"relatedInfo"];
+    }
+    NSString *description;
+    if ((description = CBCDescriptionFromClass(aClass)) != nil) {
+      [catalogMetadata setObject:CBCDescriptionFromClass(aClass) forKey:@"description"];
+    }
+    NSString *storyboardName;
+    if ((storyboardName = CBCStoryboardNameFromClass(aClass)) != nil) {
+      [catalogMetadata setObject:CBCStoryboardNameFromClass(aClass) forKey:@"storyboardName"];
+    }
+  }
+  return catalogMetadata;
+}
 
 NSDictionary *CBCCatalogMetadataFromClass(Class aClass) {
-  NSDictionary *catalogMetadata = [NSDictionary new];
+  NSDictionary *catalogMetadata;
   if ([aClass respondsToSelector:@selector(catalogMetadata)]) {
     catalogMetadata = [aClass catalogMetadata];
+  } else {
+    catalogMetadata = CBCConstructMetadataFromMethods(aClass);
   }
   return catalogMetadata;
 }

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -18,25 +18,15 @@
 #import "CBCCatalogExample.h"
 #import <objc/runtime.h>
 
-NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass);
-BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
-BOOL CBCCatalogIsPresentableFromClass(Class aClass);
-BOOL CBCCatalogIsDebugLeaf(Class aClass);
-NSString *CBCDescriptionFromClass(Class aClass);
-NSURL *CBCRelatedInfoFromClass(Class aClass);
-NSDictionary *CBCConstructMetadataFromMethods(Class aClass);
-NSString *CBCStoryboardNameFromClass(Class aClass);
-
-#pragma mark Breadcrumb retrieval
-
-NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
-  return [aClass performSelector:@selector(catalogBreadcrumbs)];
-}
-
 #pragma mark Class Invocations
 
 __attribute__((deprecated))
-BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
+static NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
+  return [aClass performSelector:@selector(catalogBreadcrumbs)];
+}
+
+__attribute__((deprecated))
+static BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   BOOL isPrimary = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
     isPrimary = [aClass catalogIsPrimaryDemo];
@@ -45,7 +35,7 @@ BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
 }
 
 __attribute__((deprecated))
-BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
+static BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   BOOL isPresentable = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
     isPresentable = [aClass catalogIsPresentable];
@@ -54,7 +44,7 @@ BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
 }
 
 __attribute__((deprecated))
-BOOL CBCCatalogIsDebugLeaf(Class aClass) {
+static BOOL CBCCatalogIsDebugLeaf(Class aClass) {
   BOOL isDebugLeaf = NO;
   if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
     isDebugLeaf = [aClass catalogIsDebug];
@@ -63,7 +53,7 @@ BOOL CBCCatalogIsDebugLeaf(Class aClass) {
 }
 
 __attribute__((deprecated))
-NSURL *CBCRelatedInfoFromClass(Class aClass) {
+static NSURL *CBCRelatedInfoFromClass(Class aClass) {
   NSURL *catalogRelatedInfo = nil;
   if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
     catalogRelatedInfo = [aClass catalogRelatedInfo];
@@ -72,7 +62,7 @@ NSURL *CBCRelatedInfoFromClass(Class aClass) {
 }
 
 __attribute__((deprecated))
-NSString *CBCDescriptionFromClass(Class aClass) {
+static NSString *CBCDescriptionFromClass(Class aClass) {
   NSString *catalogDescription = nil;
   if ([aClass respondsToSelector:@selector(catalogDescription)]) {
     catalogDescription = [aClass catalogDescription];
@@ -81,7 +71,7 @@ NSString *CBCDescriptionFromClass(Class aClass) {
 }
 
 __attribute__((deprecated))
-NSString *CBCStoryboardNameFromClass(Class aClass) {
+static NSString *CBCStoryboardNameFromClass(Class aClass) {
   NSString *catalogStoryboardName = nil;
   if ([aClass respondsToSelector:@selector(catalogStoryboardName)]) {
     catalogStoryboardName = [aClass catalogStoryboardName];
@@ -90,7 +80,7 @@ NSString *CBCStoryboardNameFromClass(Class aClass) {
 }
 
 __attribute__((deprecated))
-NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
+static NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
   NSMutableDictionary *catalogMetadata = [NSMutableDictionary new];
   if ([aClass respondsToSelector:@selector(catalogBreadcrumbs)]) {
     [catalogMetadata setObject:CBCCatalogBreadcrumbsFromClass(aClass) forKey:@"breadcrumbs"];

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -20,12 +20,10 @@
 
 #pragma mark Class Invocations
 
-__attribute__((deprecated))
 static NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass) {
   return [aClass performSelector:@selector(catalogBreadcrumbs)];
 }
 
-__attribute__((deprecated))
 static BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   BOOL isPrimary = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPrimaryDemo)]) {
@@ -34,7 +32,6 @@ static BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass) {
   return isPrimary;
 }
 
-__attribute__((deprecated))
 static BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   BOOL isPresentable = NO;
   if ([aClass respondsToSelector:@selector(catalogIsPresentable)]) {
@@ -43,7 +40,6 @@ static BOOL CBCCatalogIsPresentableFromClass(Class aClass) {
   return isPresentable;
 }
 
-__attribute__((deprecated))
 static BOOL CBCCatalogIsDebugLeaf(Class aClass) {
   BOOL isDebugLeaf = NO;
   if ([aClass respondsToSelector:@selector(catalogIsDebug)]) {
@@ -52,7 +48,6 @@ static BOOL CBCCatalogIsDebugLeaf(Class aClass) {
   return isDebugLeaf;
 }
 
-__attribute__((deprecated))
 static NSURL *CBCRelatedInfoFromClass(Class aClass) {
   NSURL *catalogRelatedInfo = nil;
   if ([aClass respondsToSelector:@selector(catalogRelatedInfo)]) {
@@ -61,7 +56,6 @@ static NSURL *CBCRelatedInfoFromClass(Class aClass) {
   return catalogRelatedInfo;
 }
 
-__attribute__((deprecated))
 static NSString *CBCDescriptionFromClass(Class aClass) {
   NSString *catalogDescription = nil;
   if ([aClass respondsToSelector:@selector(catalogDescription)]) {
@@ -70,7 +64,6 @@ static NSString *CBCDescriptionFromClass(Class aClass) {
   return catalogDescription;
 }
 
-__attribute__((deprecated))
 static NSString *CBCStoryboardNameFromClass(Class aClass) {
   NSString *catalogStoryboardName = nil;
   if ([aClass respondsToSelector:@selector(catalogStoryboardName)]) {
@@ -79,7 +72,6 @@ static NSString *CBCStoryboardNameFromClass(Class aClass) {
   return catalogStoryboardName;
 }
 
-__attribute__((deprecated))
 static NSDictionary *CBCConstructMetadataFromMethods(Class aClass) {
   NSMutableDictionary *catalogMetadata = [NSMutableDictionary new];
   if ([aClass respondsToSelector:@selector(catalogBreadcrumbs)]) {

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -20,10 +20,10 @@
 
 #pragma mark Metadata keys
 
-NSString *const CBCIsPresentable  = @"presentable";
 NSString *const CBCBreadcrumbs    = @"breadcrumbs";
-NSString *const CBCDescription    = @"description";
 NSString *const CBCIsDebug        = @"debug";
+NSString *const CBCDescription    = @"description";
+NSString *const CBCIsPresentable  = @"presentable";
 NSString *const CBCIsPrimaryDemo  = @"primaryDemo";
 NSString *const CBCRelatedInfo    = @"relatedInfo";
 NSString *const CBCStoryboardName = @"storyboardName";

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -15,10 +15,17 @@
  */
 
 #import "CBCRuntime.h"
-
 #import "CBCCatalogExample.h"
-
 #import <objc/runtime.h>
+
+NSArray<NSString *> *CBCCatalogBreadcrumbsFromClass(Class aClass);
+BOOL CBCCatalogIsPrimaryDemoFromClass(Class aClass);
+BOOL CBCCatalogIsPresentableFromClass(Class aClass);
+BOOL CBCCatalogIsDebugLeaf(Class aClass);
+NSString *CBCDescriptionFromClass(Class aClass);
+NSURL *CBCRelatedInfoFromClass(Class aClass);
+NSDictionary *CBCConstructMetadataFromMethods(Class aClass);
+NSString *CBCStoryboardNameFromClass(Class aClass);
 
 #pragma mark Breadcrumb retrieval
 


### PR DESCRIPTION
* The main focus for this PR is to add a new `NSDictionary` property to our `CBCNode` class called metadata. The intention is that from now on, any information about an example should be held there rather than in separate methods. To add key/values to the `CBCNode` metadata property, an example must implement `catalogMetadata` and return an `NSDictionary`.

* This PR also tries to clean up code that wasn't needed and/or could be improved with the new metadata addition.

* This PR allows backwards compatibility. This means that you can still use the same API methods, and also still implement the multiple catalog example methods for each `CBCNode` information (`catalogIsPresentable`, `catalogBreadcrumb`, `catalogIsPrimaryDemo` etc.). The way the `CBCNode` builder works is that it looks for a `catalogMetadata` implementation, and if there is one then it takes that dictionary, otherwise it constructs that dictionary using the old method implementations.

Example of before and after for how we should be implementing our metadata for examples:

Before:
```
+ (NSArray *)catalogBreadcrumbs {
  return @[ @"Activity Indicator", @"Activity Indicator" ];
}

+ (NSString *)catalogDescription {
  return @"Activity Indicator is a visual indication of an app loading content. It can display how "
         @"long an operation will take or visualize an unspecified wait time.";
}

+ (BOOL)catalogIsPrimaryDemo {
  return YES;
}

+ (BOOL)catalogIsPresentable {
  return YES;
}
```

After:
```
+ (NSDictionary *)catalogMetadata {
  return @{@"breadcrumbs": @[ @"Activity Indicator", @"Activity Indicator" ],
           @"description": @"Activity Indicator is a visual indication of an app loading content. It can display how "
           @"long an operation will take or visualize an unspecified wait time.",
           @"primaryDemo": @YES,
           @"presentable": @YES};
}
```