### PR TITLE
Ignore PhotoFoundation classes in the runtime lookup

### DIFF
--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -130,7 +130,7 @@ NSArray<Class> *CBCGetAllCompatibleClasses(void) {
   NSSet *ignoredClasses = [NSSet setWithArray:@[
     @"SwiftObject", @"Object", @"FigIrisAutoTrimmerMotionSampleExport", @"NSLeafProxy"
   ]];
-  NSArray *ignoredPrefixes = @[ @"Swift.", @"_", @"JS", @"WK" ];
+  NSArray *ignoredPrefixes = @[ @"Swift.", @"_", @"JS", @"WK", @"PF" ];
 
   for (int ix = 0; ix < numberOfClasses; ++ix) {
     Class aClass = classList[ix];


### PR DESCRIPTION
We were getting the following warning:

```
*** NSForwarding: warning: object 0x1208aa3f0 of class 'PFEmbeddedMulticasterImplementation' does not implement doesNotRecognizeSelector: -- abort
```

Closes https://github.com/material-foundation/cocoapods-catalog-by-convention/issues/30