### PR TITLE
Ignoring classes which otherwise cause crashes under Catalyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.2
+
+Fix a runtime crash that occurred when built and run under Catalyst (iPad app for Mac).
+
 # 2.5.1
 
 Fix a runtime crash that occurred when the PhotoFoundation framework was included in an app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.5.2
+# next
 
 Fix a runtime crash that occurred when built and run under Catalyst (iPad app for Mac).
 

--- a/CatalogByConvention.podspec
+++ b/CatalogByConvention.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CatalogByConvention"
-  s.version      = "2.5.1"
+  s.version      = "2.5.2"
   s.authors      = "Google Inc."
   s.summary      = "Tools for building a Catalog by Convention."
   s.homepage     = "https://github.com/material-foundation/cocoapods-catalog-by-convention"

--- a/CatalogByConvention.podspec
+++ b/CatalogByConvention.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CatalogByConvention"
-  s.version      = "2.5.2"
+  s.version      = "2.5.1"
   s.authors      = "Google Inc."
   s.summary      = "Tools for building a Catalog by Convention."
   s.homepage     = "https://github.com/material-foundation/cocoapods-catalog-by-convention"

--- a/src/private/CBCRuntime.m
+++ b/src/private/CBCRuntime.m
@@ -132,6 +132,11 @@ NSArray<Class> *CBCGetAllCompatibleClasses(void) {
   ]];
   NSArray *ignoredPrefixes = @[ @"Swift.", @"_", @"JS", @"WK", @"PF" ];
 
+#if TARGET_OS_UIKITFORMAC
+  ignoredClasses = [ignoredClasses setByAddingObject:@"NSScrollingBehaviorZombie"];
+  ignoredPrefixes = [ignoredPrefixes arrayByAddingObject: @"NSVB_"];
+#endif
+
   for (int ix = 0; ix < numberOfClasses; ++ix) {
     Class aClass = classList[ix];
     NSString *className = NSStringFromClass(aClass);


### PR DESCRIPTION
Catalyst (iPad apps for Mac) seems to have introduced some new proxy classes which do not respond to `isSubclassOfClass:` and therefore crash.